### PR TITLE
Convert Loadable into a Java library

### DIFF
--- a/buildSrc/src/main/java/Libraries.kt
+++ b/buildSrc/src/main/java/Libraries.kt
@@ -6,6 +6,4 @@ object Libraries {
         "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.KOTLINX_COROUTINES}"
     const val TEST_RUNNER = "androidx.test:runner:${Versions.TEST_RUNNER}"
     const val TURBINE = "app.cash.turbine:turbine:${Versions.TURBINE}"
-    const val VIEWMODEL_COMPOSE =
-        "androidx.lifecycle:lifecycle-viewmodel-compose:${Versions.LIFECYCLE}"
 }

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -4,7 +4,6 @@ object Versions {
     const val GRADLE = "7.4.1"
     const val KOTLIN = "1.8.10"
     const val KOTLINX_COROUTINES = "1.6.4"
-    const val LIFECYCLE = "2.5.1"
     const val TEST_RUNNER = "1.5.2"
     const val TURBINE = "0.12.1"
 

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -10,8 +10,8 @@ object Versions {
     val java = JavaVersion.VERSION_11
 
     object Loadable {
-        const val CODE = 2
-        const val NAME = "1.1.0"
+        const val CODE = 3
+        const val NAME = "1.2.0"
         const val SDK_COMPILE = 33
         const val SDK_MIN = 21
         const val SDK_TARGET = SDK_COMPILE

--- a/loadable/build.gradle.kts
+++ b/loadable/build.gradle.kts
@@ -1,8 +1,20 @@
 plugins {
-    id("com.android.library")
-    id("kotlin-android")
-    id("kotlin-parcelize")
+    id("java-library")
+    id("org.jetbrains.kotlin.jvm")
     `maven-publish`
+}
+
+java {
+    sourceCompatibility = Versions.java
+    targetCompatibility = Versions.java
+}
+
+dependencies {
+    implementation(Libraries.KOTLINX_COROUTINES_CORE)
+
+    testImplementation(Libraries.TURBINE)
+    testImplementation(Libraries.KOTLIN_TEST)
+    testImplementation(Libraries.KOTLINX_COROUTINES_TEST)
 }
 
 publishing {
@@ -17,59 +29,8 @@ publishing {
             version = Versions.Loadable.NAME
 
             afterEvaluate {
-                from(components[Variants.RELEASE])
+                from(components["java"])
             }
         }
     }
-}
-
-@Suppress("UnstableApiUsage")
-android {
-    namespace = Metadata.NAMESPACE
-    compileSdk = Versions.Loadable.SDK_COMPILE
-
-    defaultConfig {
-        minSdk = Versions.Loadable.SDK_MIN
-
-        @Suppress("DEPRECATION")
-        targetSdk = Versions.Loadable.SDK_TARGET
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    publishing {
-        singleVariant(Variants.RELEASE) {
-            withSourcesJar()
-            withJavadocJar()
-        }
-    }
-
-    buildTypes {
-        getByName(Variants.RELEASE) {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility = Versions.java
-        targetCompatibility = Versions.java
-    }
-
-    kotlinOptions {
-        jvmTarget = Versions.java.toString()
-    }
-}
-
-@Suppress("SpellCheckingInspection")
-dependencies {
-    implementation(Libraries.VIEWMODEL_COMPOSE)
-    implementation(Libraries.KOTLINX_COROUTINES_CORE)
-
-    testImplementation(Libraries.TURBINE)
-    testImplementation(Libraries.KOTLIN_TEST)
-    testImplementation(Libraries.KOTLINX_COROUTINES_TEST)
 }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt
@@ -1,13 +1,10 @@
 package com.jeanbarrossilva.loadable
 
-import android.os.Parcelable
 import java.io.Serializable
-import kotlinx.parcelize.Parcelize
 
 /** Different stages of asynchronously-loaded content. **/
-sealed interface Loadable<T : Serializable?> : Parcelable {
+sealed interface Loadable<T : Serializable?> : Serializable {
     /** Stage in which the content is being loaded and, therefore, is temporarily unavailable. **/
-    @Parcelize
     class Loading<T : Serializable?> : Loadable<T> {
         override fun toString(): String {
             return "Loading"
@@ -19,7 +16,6 @@ sealed interface Loadable<T : Serializable?> : Parcelable {
      *
      * @param value Content that's been successfully loaded.
      **/
-    @Parcelize
     data class Loaded<T : Serializable?>(val value: T) : Loadable<T>
 
     /**
@@ -27,6 +23,5 @@ sealed interface Loadable<T : Serializable?> : Parcelable {
      *
      * @param error [Throwable] that's been thrown while trying to load the content.
      **/
-    @Parcelize
     data class Failed<T : Serializable?>(val error: Throwable) : Loadable<T>
 }


### PR DESCRIPTION
Makes so that this library is not tied to Android and turns the main module, [`:loadable`](https://github.com/jeanbarrossilva/loadable-android/tree/155e3a5bd9bc49b2268b893ab80714eef3074f79/loadable), into a Java one.