### PR TITLE
Upgrade coroutines to 1.7.2

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -8,7 +8,7 @@ object Versions {
     const val COMPOSE_UI = "1.4.3"
     const val GRADLE = "7.4.1"
     const val KOTLIN = "1.8.21"
-    const val KOTLINX_COROUTINES = "1.6.4"
+    const val KOTLINX_COROUTINES = "1.7.2"
     const val ROBOLECTRIC = "4.9"
     const val TEST_RUNNER = "1.5.2"
     const val TURBINE = "0.12.1"

--- a/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/flow/FlowExtensionsTests.kt
+++ b/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/flow/FlowExtensionsTests.kt
@@ -11,14 +11,12 @@ import com.jeanbarrossilva.loadable.list.toListLoadable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.runTest
 
 internal class FlowExtensionsTests {
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN some content WHEN creating ListLoadable Flow with it THEN it emits Loading followed by the matching ListLoadable`() { // ktlint-disable max-line-length
         runTest {
@@ -30,7 +28,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a ListLoadable Flow WHEN filtering by non-loading values THEN it's filtered`() {
         runTest {
@@ -51,7 +48,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Flow WHEN converting it into a ListLoadable Flow THEN the initial value is loading`() { // ktlint-disable max-line-length
         runTest {
@@ -61,7 +57,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Flow with an empty list WHEN converting it into a ListLoadable THEN it is empty`() { // ktlint-disable max-line-length
         runTest {
@@ -72,7 +67,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Flow with a populated list WHEN converting it into a ListLoadable THEN it is populated`() { // ktlint-disable max-line-length
         runTest {
@@ -85,7 +79,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a failed Flow WHEN converting it into a ListLoadable THEN it is failed`() { // ktlint-disable max-line-length
         runTest {

--- a/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/flow/MutableStateFlowExtensionsTests.kt
+++ b/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/flow/MutableStateFlowExtensionsTests.kt
@@ -6,11 +6,9 @@ import com.jeanbarrossilva.loadable.list.serializableListOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 
 internal class MutableStateFlowExtensionsTests {
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a SerializableList WHEN creating a ListLoadable Flow with it THEN it's created`() {
         runTest {
@@ -20,7 +18,6 @@ internal class MutableStateFlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN an Array WHEN creating a ListLoadable Flow with it THEN it's created`() {
         runTest {
@@ -30,7 +27,6 @@ internal class MutableStateFlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN some content WHEN creating a ListLoadable StateFlow with it THEN it emits Loading followed by the matching ListLoadable`() { // ktlint-disable max-line-length
         runTest {

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/LoadableScopeTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/LoadableScopeTests.kt
@@ -2,7 +2,6 @@ package com.jeanbarrossilva.loadable
 
 import java.io.Serializable
 import kotlin.test.assertIs
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -18,21 +17,18 @@ internal class LoadableScopeTests {
     }
 
     @Test
-    @OptIn(ExperimentalCoroutinesApi::class)
     fun `GIVEN a Loading Loadable WHEN sending it to the scope THEN it's received`() {
         runTest { scope.load() }
         assertIs<Loadable.Loading<Serializable?>>(sent.single())
     }
 
     @Test
-    @OptIn(ExperimentalCoroutinesApi::class)
     fun `GIVEN a Loaded Loadable WHEN sending it to the scope THEN it's received`() {
         runTest { scope.load(null) }
         assertEquals(Loadable.Loaded(null), sent.single())
     }
 
     @Test
-    @OptIn(ExperimentalCoroutinesApi::class)
     fun `GIVEN a Failed Loadable WHEN sending it to the scope THEN it's received`() {
         runTest { scope.fail(NullPointerException()) }
         sent.single().let {

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
@@ -5,14 +5,12 @@ import com.jeanbarrossilva.loadable.Loadable
 import java.io.Serializable
 import kotlin.test.Test
 import kotlin.test.assertIs
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 
 internal class FlowExtensionsTests {
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Loadable Flow built through a scope WHEN loading THEN a Loading has been emitted`() { // ktlint-disable max-line-length
         runTest {
@@ -23,7 +21,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Loadable Flow built through a scope WHEN loaded THEN a Loaded has been emitted`() {
         runTest {
@@ -34,7 +31,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Loadable Flow built through a scope WHEN failed THEN a Failed has been emitted`() {
         runTest {
@@ -45,7 +41,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Loadable Flow without an initial content WHEN collecting it THEN the value that's emitted first is a Loading one`() { // ktlint-disable max-line-length
         runTest {
@@ -55,7 +50,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Loadable Flow with an initial content WHEN collecting it THEN the value that's emitted first is a Loaded one`() { // ktlint-disable max-line-length
         runTest {
@@ -65,7 +59,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Loadable Flow WHEN filtering Failed values THEN they're all emitted`() {
         runTest {
@@ -82,7 +75,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Loadable Flow WHEN filtering Loaded values THEN they're all emitted`() {
         runTest {
@@ -102,7 +94,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Loadable Flow WHEN inner-mapping it THEN the emitted values are transformed`() {
         runTest {
@@ -122,7 +113,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Flow WHEN converting it into a Loadable one THEN the value that's emitted first is a Loaded one`() { // ktlint-disable max-line-length
         runTest {
@@ -134,7 +124,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Flow WHEN converting it into a Loadable one THEN its values are emitted as Loaded`() { // ktlint-disable max-line-length
         runTest {
@@ -152,7 +141,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Suppress("DIVISION_BY_ZERO")
     @Test
     fun `GIVEN a Flow WHEN converting it into a Loadable one THEN thrown exceptions are emitted as Failed`() { // ktlint-disable max-line-length
@@ -167,7 +155,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Flow WHEN converting it into a Loadable one in a CoroutineScope THEN Loading is only emitted once as an initial value`() { // ktlint-disable max-line-length
         runTest {
@@ -178,7 +165,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Suppress("SpellCheckingInspection")
     @Test
     fun `GIVEN a Loadable Flow WHEN unwrapping it THEN only Loaded Loadables' contents are emitted`() { // ktlint-disable max-line-length
@@ -198,7 +184,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Loadable Flow WHEN unwrapping its content THEN only Loaded values with non-null content are emitted`() { // ktlint-disable max-line-length
         runTest {
@@ -217,7 +202,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Suppress("SpellCheckingInspection")
     @Test
     fun `GIVEN a Loadable Flow that's Loading WHEN sending its Loadables into a LoadableScope THEN it loads`() { // ktlint-disable max-line-length
@@ -228,7 +212,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Suppress("SpellCheckingInspection")
     @Test
     fun `GIVEN a Loadable Flow that's Loaded WHEN sending its Loadables into a LoadableScope THEN it loads the content`() { // ktlint-disable max-line-length
@@ -240,7 +223,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Suppress("SpellCheckingInspection")
     @Test
     fun `GIVEN a Loadable Flow that's Failed WHEN sending its Loadables into a LoadableScope THEN it fails`() { // ktlint-disable max-line-length
@@ -257,7 +239,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `GIVEN a Flow WHEN loading it to the LoadableScope of a public Loadable-Flow-creator function THEN it's initially Loading once`() { // ktlint-disable max-line-length
         runTest {
@@ -269,7 +250,6 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Suppress("CAST_NEVER_SUCCEEDS")
     @Test
     fun `GIVEN a Loadable ChannelFlow WHEN emitting from different scopes THEN it receives sent emissions`() { // ktlint-disable max-line-length


### PR DESCRIPTION
Also removes `@OptIn(ExperimentalCoroutinesApi::class)` from tests that use [`runTest`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/run-test.html).